### PR TITLE
Cancel subscription endpoint

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::SubscriptionsController < ApplicationController
   before_action :require_valid_customer, except: :update
   before_action :require_valid_tea, except: :update
+  before_action :require_valid_status
 
   def create
     subscription = Subscription.new(subscription_params)
@@ -41,5 +42,11 @@ class Api::V1::SubscriptionsController < ApplicationController
 
   def subscription_params
     params.permit(:customer_id, :tea_id, :title, :price, :frequency, :status)
+  end
+
+  def require_valid_status
+    if params[:status] && params[:status] != "active" && params[:status] != "cancelled"
+      render json: { error: 'bad request' }, status: :bad_request
+    end
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -15,5 +15,5 @@ class Subscription < ApplicationRecord
     quarterly: 2,
     yearly: 3
   }
-  
+
 end

--- a/spec/requests/api/v1/subscriptions/cancel_subscription_spec.rb
+++ b/spec/requests/api/v1/subscriptions/cancel_subscription_spec.rb
@@ -10,5 +10,29 @@ RSpec.describe 'cancel subscription endpoint' do
 
     expect(response).to be_successful
     expect(response.status).to eq(200)
+
+    subscription = JSON.parse(response.body, symbolize_names: true)
+
+    expect(subscription[:data][:attributes][:status]).to eq('cancelled')
+  end
+
+  it 'returns an error if the subscription does not exist' do
+    customer1 = Customer.create!(first_name: 'Jamie', last_name: 'Pace', email: 'fake_email@email.com', address: '123 Address, CO')
+    tea1 = Tea.create!(title: 'Earl Grey', description: 'Good tea', temperature: 100, brew_time: '5 minutes')
+
+    patch '/api/v1/subscriptions/8888', params: { status: "cancelled" }
+
+    expect(response).to_not be_successful
+    expect(response.status).to eq(400)
+  end
+
+  it 'returns an error if given an invalid status' do
+    customer1 = Customer.create!(first_name: 'Jamie', last_name: 'Pace', email: 'fake_email@email.com', address: '123 Address, CO')
+    tea1 = Tea.create!(title: 'Earl Grey', description: 'Good tea', temperature: 100, brew_time: '5 minutes')
+    subscription1 = Subscription.create!(customer_id: customer1.id, tea_id: tea1.id, title: 'Weekly Earl Grey', price: 10.00, frequency: 'weekly')
+
+    patch "/api/v1/subscriptions/#{subscription1.id}", params: { status: "pending" }
+
+    require 'pry'; binding.pry
   end
 end

--- a/spec/requests/api/v1/subscriptions/cancel_subscription_spec.rb
+++ b/spec/requests/api/v1/subscriptions/cancel_subscription_spec.rb
@@ -31,8 +31,9 @@ RSpec.describe 'cancel subscription endpoint' do
     tea1 = Tea.create!(title: 'Earl Grey', description: 'Good tea', temperature: 100, brew_time: '5 minutes')
     subscription1 = Subscription.create!(customer_id: customer1.id, tea_id: tea1.id, title: 'Weekly Earl Grey', price: 10.00, frequency: 'weekly')
 
-    patch "/api/v1/subscriptions/#{subscription1.id}", params: { status: "pending" }
+    patch "/api/v1/subscriptions/#{subscription1.id}", params: { status: 'pending' }
 
-    require 'pry'; binding.pry
+    expect(response).to_not be_successful
+    expect(response.status).to eq(400)
   end
 end


### PR DESCRIPTION
- Add sad path testing
- Add before action callback for valid status that returns error if status is not 'active' or 'cancelled'
- Testing at 100% per SimpleCov